### PR TITLE
Remove reference to deprecated attr/xattr.h

### DIFF
--- a/jni/com_myJava_file_metadata_posix_jni_wrapper_FileAccessWrapper.c
+++ b/jni/com_myJava_file_metadata_posix_jni_wrapper_FileAccessWrapper.c
@@ -8,7 +8,8 @@
 #include <jni.h>
 #include <grp.h>
 #include <pwd.h>
-#include <attr/xattr.h>
+#include <attr/attributes.h>
+#include <sys/xattr.h>
 #include <sys/acl.h>
 #include <acl/libacl.h>
 #include "com_myJava_file_metadata_posix_jni_wrapper_FileAccessWrapper.h"


### PR DESCRIPTION
Version 2.4.48 or attr removed attr/xattr.h and
recommends to use sys/xattr.h instead. For
reference see:

https://git.savannah.nongnu.org/cgit/attr.git/commit/?id=7921157890d07858d092f4003ca4c6bae9fd2c38

I stumbled upon this through NixOS/nixpkgs#53716.

PS: I'm not sure that this is the right place for merge requests for areca.